### PR TITLE
ldapdn.rb - remove paths from commands variables

### DIFF
--- a/lib/puppet/provider/ldapdn/ldapdn.rb
+++ b/lib/puppet/provider/ldapdn/ldapdn.rb
@@ -4,9 +4,9 @@ require 'tempfile'
 Puppet::Type.type(:ldapdn).provide :ldapdn do
   desc ""
 
-  commands :ldapmodifycmd => "/usr/bin/ldapmodify"
-  commands :ldapaddcmd => "/usr/bin/ldapadd"
-  commands :ldapsearchcmd => "/usr/bin/ldapsearch"
+  commands :ldapmodifycmd => "ldapmodify"
+  commands :ldapaddcmd => "ldapadd"
+  commands :ldapsearchcmd => "ldapsearch"
 
   def create()
     ldap_apply_work


### PR DESCRIPTION
Linux like paths were hardcoded in the provider, rendering the provider useless on operating systems where ldap utilities were installed in different paths (like /usr/local/bin on FreeBSD for example). Removing absolute paths allows Puppet's provider to check the operating system PATH and find the commands where they're installed instead of failing.
