### PR TITLE
search for user _and_ operational attributes

### DIFF
--- a/lib/puppet/provider/ldapdn/ldapdn.rb
+++ b/lib/puppet/provider/ldapdn/ldapdn.rb
@@ -105,9 +105,9 @@ Puppet::Type.type(:ldapdn).provide :ldapdn do
 
   def ldap_work_to_do(asserted_attributes)
     if resource[:remote_ldap]
-      command = [command(:ldapsearchcmd), "-H", "ldap://#{resource[:remote_ldap]}", "-b", resource[:dn], "-s", "base", "-LLL", "-d", "0"]
+      command = [command(:ldapsearchcmd), "-H", "ldap://#{resource[:remote_ldap]}", "-b", resource[:dn], "-s", "base", "-LLL", "-d", "0", "+", "*"]
     else
-      command = [command(:ldapsearchcmd), "-H", "ldapi:///", "-b", resource[:dn], "-s", "base", "-LLL", "-d", "0"]
+      command = [command(:ldapsearchcmd), "-H", "ldapi:///", "-b", resource[:dn], "-s", "base", "-LLL", "-d", "0", "+", "*"]
     end
     command += resource[:auth_opts] || ["-QY", "EXTERNAL"]
     begin


### PR DESCRIPTION
Include both attribute types in searches so that attributes can be set and managed idempotently for user accounts.

In the case of unique operational attributes, such as pwdPolicySubentry, the ldapsearch should return the attribute and value if it exists. Otherwise subsequent attempts are considered 'add' rather than 'replace' operations.

With search parameters - also setting '*' to output user attrs since only specifying '+' suppresses them in favour of the operational attrs.